### PR TITLE
Fix direction and station mix up 2

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,23 +214,23 @@ def handle_get_off(text, ticket_inspector):
             return ticket_inspector
 
 
-def check_if_station_is_actually_direction(unformatted_text, ticket_inspector):
-    if ticket_inspector.line is None:
-        return ticket_inspector
-
-    if ticket_inspector.direction is None:
-        return ticket_inspector
-
-    if ticket_inspector.station is None:
-        return ticket_inspector
-
-    line = ticket_inspector.line.lower()
-    text = unformatted_text.lower()
-
-    # Get the final stations of the line
+def get_final_stations_of_line(line):
     final_stations_of_line = []
-    final_stations_of_line.append(lines_with_stations[ticket_inspector.line][0])
-    final_stations_of_line.append(lines_with_stations[ticket_inspector.line][-1])
+    final_stations_of_line.append(lines_with_stations[line][0])
+    final_stations_of_line.append(lines_with_stations[line][-1])
+    return final_stations_of_line
+
+
+def check_if_station_is_actually_direction(text, ticket_inspector):
+    if ticket_inspector.direction is None or ticket_inspector.station is None:
+        return ticket_inspector
+
+    line = ticket_inspector.line
+    # Get the final stations of the line
+    final_stations_of_line = get_final_stations_of_line(line)
+
+    # Convert the line to lowercase because the text is also in lowercase
+    line = line.lower()
 
     # Get the word after the line
     line_index = text.rfind(line)
@@ -247,7 +247,7 @@ def check_if_station_is_actually_direction(unformatted_text, ticket_inspector):
             if found_station in final_stations_of_line:
                 # create text without the found station
                 text_without_direction = remove_direction_and_keyword(
-                    unformatted_text,
+                    text,
                     line,
                     after_line_words[0]
                 )
@@ -267,16 +267,12 @@ def check_if_station_is_actually_direction(unformatted_text, ticket_inspector):
     return ticket_inspector
 
 
-def correct_direction(ticket_inspector, lines_with_final_station):
+def correct_direction(ticket_inspector, lines_with_stations):
     line = ticket_inspector.line
     direction = ticket_inspector.direction
     station = ticket_inspector.station
 
-    # If we don't have a line, we can't correct the direction
-    if line is None:
-        return ticket_inspector
-
-    stations_of_line = lines_with_final_station[line]
+    stations_of_line = lines_with_stations[line]
 
     # If direction is a final station, return ticket_inspector
     if direction in [stations_of_line[0], stations_of_line[-1]]:
@@ -311,6 +307,9 @@ def set_ringbahn_directionless(ticket_inspector):
 def verify_direction(ticket_inspector, text):
     # direction should be None if the ticket inspector got off the train
     handle_get_off(text, ticket_inspector)
+
+    if ticket_inspector.line is None:
+        return ticket_inspector
     
     # Check if the direction is the final station of the line and correct it
     correct_direction(ticket_inspector, lines_with_stations)

--- a/main.py
+++ b/main.py
@@ -214,7 +214,7 @@ def handle_get_off(text, ticket_inspector):
             return ticket_inspector
 
 
-def check_if_station_is_actually_direction(unformatted_text, ticket_inspector): # this rule needs to be adjusted so that it is higher in priority than catch secret direction
+def check_if_station_is_actually_direction(unformatted_text, ticket_inspector):
     if ticket_inspector.line is None:
         return ticket_inspector
 
@@ -385,7 +385,7 @@ if __name__ == '__main__':
 
     print('Bot is running...🏃‍♂️')
 
-    @bot.message_handler(func=lambda message: message.chat.type == 'private')
+    @bot.message_handler(func=lambda message: message.chat.type == 'private')  # private for testing
     def get_info(message):
         author_id = message.chat.id
         current_time = datetime.datetime.now()
@@ -405,6 +405,12 @@ if __name__ == '__main__':
                 last_message['time'] = current_time  # Update the timestamp to the latest message
                 info = extract_ticket_inspector_info(merged_text)
                 last_message['info'] = info
+
+                # Print the information after merging the messages
+                if info:
+                    print('Found Info:', info)
+                else:
+                    print('No valuable information found')
             else:
                 # Handle as a new message
                 process_new_message(author_id, message, current_time)

--- a/main.py
+++ b/main.py
@@ -204,6 +204,7 @@ def handle_get_off(text, ticket_inspector):
     # if any of the keywords are in the text return True
     for keyword in getting_off_keywords:
         if keyword in text:
+            # When getting off, we only know they are at a station
             ticket_inspector.line = None
             ticket_inspector.direction = None
             return ticket_inspector

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from NER.TransportInformationRecognizer import TextProcessor
 
 class TicketInspector:
     def __init__(self, line, station, direction):
-        # self.time = time
         self.line = line
         self.station = station
         self.direction = direction
@@ -73,7 +72,6 @@ def find_line(text, lines):
 
 
 def format_text(text):
-    # Replace all '-' with whitespaces and convert to lowercase
     text = text.lower().replace('.', ' ').replace(',', ' ')
     # Remove all isolated 's' and 'u' to reduce noise
     text = re.sub(r'\b(s|u)\b', '', text)
@@ -127,7 +125,6 @@ def find_station(text, ticket_inspector, threshold=75):
     
     # Use the NER Model to get the unrecognized stations from the text
     ner_results = TextProcessor.process_text(text)
-    print('NER Results:', ner_results)
 
     for ner_result in ner_results:
         # Get the fuzzy match of the NER result with the stations
@@ -144,14 +141,12 @@ def find_station(text, ticket_inspector, threshold=75):
                         direction = find_match_in_stations(best_match, stations_with_synonyms)
                         if direction:
                             ticket_inspector.direction = direction
-                            print('Secret direction:', ticket_inspector.direction)
                 return found_station_name
     return None
 
 
 def remove_direction_and_keyword(text, direction_keyword, direction):
     if direction_keyword and direction:
-        print('Removing direction and keyword:', direction_keyword, direction)
         replace_segment = f'{direction_keyword} {direction}'
         text_without_direction = text.replace(replace_segment, '').strip()
         return text_without_direction
@@ -349,13 +344,11 @@ def extract_ticket_inspector_info(unformatted_text):
     # Get the direction
     text = format_text(unformatted_text)
     found_direction = find_direction(text, ticket_inspector)[0]
-    print('Found Direction:', found_direction)
     ticket_inspector.direction = found_direction
 
     # Get the station
     text_without_direction = find_direction(text, ticket_inspector)[1]
     found_station = find_station(text_without_direction, ticket_inspector)
-    print('Found Station:', found_station)
     ticket_inspector.station = found_station
 
     # Verify the direction and line with the given information

--- a/main.py
+++ b/main.py
@@ -221,48 +221,40 @@ def get_final_stations_of_line(line):
     return final_stations_of_line
 
 
+def get_words_after_line(text, line):
+    line_index = text.rfind(line)
+    after_line = text[line_index + len(line):].strip()
+    return after_line.split()
+
+
 def check_if_station_is_actually_direction(text, ticket_inspector):
     if ticket_inspector.direction is None or ticket_inspector.station is None:
         return ticket_inspector
 
     line = ticket_inspector.line
-    # Get the final stations of the line
     final_stations_of_line = get_final_stations_of_line(line)
 
-    # Convert the line to lowercase because the text is also in lowercase
-    line = line.lower()
+    line = line.lower()  # convert to lowercase because text is in lowercase
+    after_line_words = get_words_after_line(text, line)
 
-    # Get the word after the line
-    line_index = text.rfind(line)
-    after_line = text[line_index + len(line):].strip()
-    after_line_words = after_line.split()
-    if len(after_line_words) > 0:
-        print('Word after line:', after_line_words[0])
-        # Check if the word after the line is a station
-        found_station = find_station(after_line_words[0], ticket_inspector)
-        print('Station found after line:', found_station)
+    if not after_line_words:
+        return ticket_inspector
 
-        if found_station:
-            # Check if the station matches one of the final stations of the line
-            if found_station in final_stations_of_line:
-                # create text without the found station
-                text_without_direction = remove_direction_and_keyword(
-                    text,
-                    line,
-                    after_line_words[0]
-                )
-                print('Text without direction:', text_without_direction)
+    # Get the word directly after the line
+    found_station_after_line = find_station(after_line_words[0], ticket_inspector)
 
-                # get a new station
-                new_station = find_station(text_without_direction, ticket_inspector)
-                print('New station:', new_station)
-                if new_station is not None:
+    if not found_station_after_line or found_station_after_line not in final_stations_of_line:
+        return ticket_inspector
 
-                    ticket_inspector.direction = found_station
-                    ticket_inspector.station = new_station
-                    print('Station is actually direction:', ticket_inspector.station)
+    # Remove the word after line from the text to find the new station
+    text_without_direction = remove_direction_and_keyword(text, line, after_line_words[0])
+    new_station = find_station(text_without_direction, ticket_inspector)
 
-                    return ticket_inspector
+    if new_station is None:
+        return ticket_inspector
+
+    ticket_inspector.direction = found_station_after_line
+    ticket_inspector.station = new_station
 
     return ticket_inspector
 

--- a/test_cases.py
+++ b/test_cases.py
@@ -1411,7 +1411,7 @@ test_cases = [
      'U6 naturkundemuseum Richtung Kurt Schumacher',
      'Naturkundemuseum',
      'U6',
-     'Kurt-Schumacher-Platz'),
+     'Alt-Tegel'),
     (
      'Blauwesten',
      None, None, None),


### PR DESCRIPTION
After integrating the changes, I refined the check_if_station_is_actually_direction function to address a critical issue where it was previously not possible to designate a station as a direction. This adjustment was carefully implemented to maintain stringent rules, minimizing the risk of false positives.

The revised function operates under the principle that the presence of both a defined station and direction indicates a higher likelihood of accuracy, with the station being of paramount importance. This approach is exemplified in scenarios like 'U8 Hermannstraße', where, despite the potential for reinterpretation by check_if_station_is_actually_direction, the initial designation of 'Hermannstraße' as a station is preserved due to its precedence over direction.

If either the station or direction is undefined, the function assumes the existing information is likely accurate, avoiding unnecessary adjustments. This decision prioritizes the integrity of the station information, which is deemed more crucial.

The function then proceeds to verify if the word immediately following the line identifier could represent a direction, as seen in 'U8 Hermannstraße'. In cases where 'Hermannstraße' accurately reflects the direction for 'U8', the function seeks a new station within the modified text (excluding the previously identified direction). If a new station is found, it is set as the current station, and the original station is reassigned as the direction.

For instance, with the input 'S7 Ahrensfelde jetzt Alexanderplatz', the function recognizes 'Ahrensfelde' as the correct direction for 'S7'. It then examines the text 'S7 jetzt Alexanderplatz' for any station mentions, identifies 'Alexanderplatz' as a valid station, and updates the station and direction accordingly.

Additionally, I have streamlined the code to enhance readability and efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced functionality to retrieve final stations of a line.
	- Enhanced direction handling based on station positions.
	- Added capability to set direction to None for specific lines.

- **Improvements**
	- Improved direction verification to handle various scenarios related to direction and station updates.

- **Bug Fixes**
	- Fixed character replacements in text formatting.
	- Corrected station and direction checks to enhance reliability.

- **Refactor**
	- Removed unnecessary `time` initialization in `TicketInspector`.
	- Updated message handling in information retrieval function.

- **Tests**
	- Updated test cases to reflect changes in public transportation directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->